### PR TITLE
Moving 'update-project-profile' template here from hackforla/website …

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-project-profile---name-of-project-.md
+++ b/.github/ISSUE_TEMPLATE/update-project-profile---name-of-project-.md
@@ -1,0 +1,24 @@
+---
+name: 'Update Project Profile: [name of project]'
+about: We are making a project home page for each project and need some additional
+  info
+title: 'Update Project Profile: [name of project]'
+labels: documentation, priority
+assignees: ''
+
+---
+
+### Overview
+Update the following fields for your project. These updated fields will then be updated to be shown on the website.
+
+### Action Items
+- [ ] Update wording of anything currently on the project card (see [hackforla.org](https://www.hackforla.org/))
+- [ ] Update "Tools" Section to display the tools being used for the project (Ex: figma, Balsamiq, photoshop, etc.)
+- [ ] Update "Looking For" Section
+- [ ] Update any links that are not currently displayed on the site (do you have a demo site?)
+- [ ] Banner Image to be displayed on project specific page 16:9 ratio (min width 1200px)
+- [ ] Any resources for a Getting Started link (either a link to a wiki or readme)
+
+### Resources/Instructions
+Rough example of a good banner image from the helloGOV project:
+![](https://user-images.githubusercontent.com/37763229/71553521-b75f6580-29c5-11ea-892e-0f0391069dc7.png)


### PR DESCRIPTION
We want to be able to use the organization-wide issue templates in the website repository so we need to remove website's .github/ISSUE_TEMPLATE directory so these templates are available. 

Step 1 for that is to move website's update-project-profile---name-of-project-.md template here.